### PR TITLE
Improve mobile UI layout and top stat display

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 <button id="toolSpike" class="toolbtn">Spike Floor <span style="float:right;">6</span></button>
 </div>
 <div class="row"><button id="btnPlace" class="btn">Place Selected</button><button id="btnDash" class="btn ghost">Dash (arm)</button></div>
-<div class="row"><button id="btnNew" class="btn primary">New Game</button><button id="btnHelp" class="btn">Help</button></div>
+<div class="row"><button id="btnHelp" class="btn">Help</button><button id="btnNew" class="btn danger">New Game</button></div>
 <div class="dpad" aria-label="Touch movement controls">
 <div class="pad-empty"></div><button class="padbtn" data-dir="up">▲</button><div class="pad-empty"></div>
 <button class="padbtn" data-dir="left">◀</button><div class="pad-empty"></div><button class="padbtn" data-dir="right">▶</button>

--- a/styles.css
+++ b/styles.css
@@ -4,14 +4,14 @@
 .wrap{display:grid;grid-template-columns:1fr 360px;gap:16px;width:min(1300px,100%);padding:12px}@media(max-width:900px){.wrap{grid-template-columns:1fr}}
 .panel{background:linear-gradient(180deg,#1a1f36,#121528);border:1px solid rgba(255,255,255,.06);border-radius:14px;box-shadow:0 8px 24px rgba(0,0,0,.35),inset 0 1px 0 rgba(255,255,255,.06);padding:12px}
 h1{font-size:18px;margin:0 0 6px;font-weight:700;letter-spacing:.4px}
-.hud{display:grid;grid-template-columns:repeat(6,minmax(0,1fr));gap:8px;align-items:center;margin-bottom:8px}
-.stat{display:grid;grid-template-columns:auto 1fr;gap:8px;align-items:center;padding:8px 10px;border-radius:10px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)}
+.hud{display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin-bottom:8px}
+.stat{display:flex;justify-content:space-between;align-items:center;flex:1 1 120px;gap:8px;padding:8px 12px;border-radius:10px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06)}
 .stat.hp.flash{background:rgba(255,107,107,.18);color:#ffd1d1}.stat .label{font-size:12px;color:var(--muted);line-height:1}.stat .value{font-weight:700;font-size:16px}
 #gameCanvas{width:100%;aspect-ratio:1/1;display:block;border-radius:12px;background:#0e1020;outline:1px solid rgba(255,255,255,.06);touch-action:manipulation}
 .right{display:grid;grid-template-rows:auto auto 1fr auto;gap:12px}
 .btn{cursor:pointer;user-select:none;padding:10px 12px;border-radius:10px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,#283053,#1b2142);color:var(--text);font-weight:700;letter-spacing:.2px;text-align:center}
-.btn:active{transform:translateY(1px) scale(.99)}.btn.primary{background:linear-gradient(180deg,#2b6fff,#184fe8);border-color:#2b6fff}.btn.ghost{background:rgba(255,255,255,.04)}
-.row{display:grid;grid-template-columns:1fr 1fr;gap:8px}.tools{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+.btn:active{transform:translateY(1px) scale(.99)}.btn.primary{background:linear-gradient(180deg,#2b6fff,#184fe8);border-color:#2b6fff}.btn.ghost{background:rgba(255,255,255,.04)}.btn.danger{background:linear-gradient(180deg,#ff4d4f,#d9363e);border-color:#ff4d4f;color:#fff}
+.row{display:grid;grid-template-columns:1fr 1fr;gap:8px}.row+.row{margin-top:8px}.tools{display:grid;grid-template-columns:1fr 1fr;gap:8px}
 .toolbtn{padding:8px 10px;border-radius:10px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.03);color:var(--text);font-weight:700;text-align:left}
 .toolbtn.active{outline:2px solid var(--accent);background:rgba(103,212,255,.08)}.tileLegend{display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:12px;color:var(--muted)}
 .legendItem{display:grid;grid-template-columns:16px 1fr;gap:6px;align-items:center}.swatch{width:16px;height:16px;border-radius:4px}


### PR DESCRIPTION
## Summary
- Reposition Help and New Game buttons and add red danger styling to avoid accidental taps
- Switch HUD stats to a flex layout so large numbers no longer clip and wrap cleanly
- Add spacing between mobile control rows for clearer separation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5d14545483249ab84fbe17b0f706