### PR TITLE
Add minimal package.json for npm tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "escape-the-siege",
+  "version": "1.0.0",
+  "description": "Development test configuration for Escape The Siege",
+  "scripts": {
+    "test": "node --test"
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal `package.json` with `npm test` script using Node's built-in test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab5e54e9dc83249283a3bf393eb393