### PR TITLE
Fix runtime error causing black screen

### DIFF
--- a/main.js
+++ b/main.js
@@ -87,8 +87,5 @@ btnHelp.addEventListener('click',()=>{
 
 });
 
-main
-  
-  
 function loop(ts){animT=ts;draw();requestAnimationFrame(loop)}resetState();requestAnimationFrame(loop);
 })();


### PR DESCRIPTION
## Summary
- Remove stray `main` identifier at end of main.js that crashed initialization and left the game canvas black
- Game loop now runs and board renders normally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab8f5d55888324a65492767f02b551