### PR TITLE
Move help and new game controls to bottom of mobile UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,12 +22,13 @@
 <button id="toolSpike" class="toolbtn">Spike Floor <span style="float:right;">6</span></button>
 </div>
 <div class="row"><button id="btnPlace" class="btn">Place Selected</button><button id="btnDash" class="btn ghost">Dash (arm)</button></div>
-<div class="row"><button id="btnHelp" class="btn">Help</button><button id="btnNew" class="btn danger">New Game</button></div>
 <div class="dpad" aria-label="Touch movement controls">
 <div class="pad-empty"></div><button class="padbtn" data-dir="up">▲</button><div class="pad-empty"></div>
 <button class="padbtn" data-dir="left">◀</button><div class="pad-empty"></div><button class="padbtn" data-dir="right">▶</button>
 <div class="pad-empty"></div><button class="padbtn" data-dir="down">▼</button><div class="pad-empty"></div>
-</div></div></div>
+</div>
+<div class="row bottomBtns"><button id="btnHelp" class="btn">Help</button><button id="btnNew" class="btn danger">New Game</button></div>
+</div></div>
 <div class="panel right"><div class="palette"><div class="tileLegend">
 <div class="legendItem"><div class="swatch" style="background:#0a0e1a;border:1px solid #3b486b"></div><div>Wall</div></div>
 <div class="legendItem"><div class="swatch" style="background:#263667"></div><div>Floor</div></div>

--- a/styles.css
+++ b/styles.css
@@ -16,7 +16,8 @@ h1{font-size:18px;margin:0 0 6px;font-weight:700;letter-spacing:.4px}
 .toolbtn.active{outline:2px solid var(--accent);background:rgba(103,212,255,.08)}.tileLegend{display:grid;grid-template-columns:1fr 1fr;gap:6px;font-size:12px;color:var(--muted)}
 .legendItem{display:grid;grid-template-columns:16px 1fr;gap:6px;align-items:center}.swatch{width:16px;height:16px;border-radius:4px}
 .log{height:120px;overflow:auto;padding:8px;border-radius:10px;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.06);font-size:12px;line-height:1.3}.log p{margin:0 0 6px;color:var(--muted)}
-.mobileControls{display:grid;gap:8px;margin-top:10px;user-select:none}.dpad{width:100%;display:grid;grid-template-columns:1fr 1fr 1fr;grid-template-rows:1fr 1fr 1fr;gap:6px;place-items:stretch}
+.mobileControls{display:grid;gap:8px;margin-top:10px;user-select:none}.bottomBtns{margin-top:16px}
+.dpad{width:100%;display:grid;grid-template-columns:1fr 1fr 1fr;grid-template-rows:1fr 1fr 1fr;gap:6px;place-items:stretch}
 .dpad .padbtn{min-height:54px;border-radius:10px;border:1px solid rgba(255,255,255,.08);background:linear-gradient(180deg,#22294b,#171d3a);color:var(--text);font-weight:800;font-size:16px;display:grid;place-items:center}
 .pad-empty{background:transparent;border:none}.footer{color:var(--muted);font-size:12px;text-align:center}.pill{display:inline-block;padding:2px 8px;border-radius:999px;font-size:12px;font-weight:700;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.12)}
 .placeMode{outline:2px solid var(--accent)}.dashArmed{filter:drop-shadow(0 0 6px #67d4ff)}


### PR DESCRIPTION
## Summary
- Reposition Help and New Game buttons beneath the d-pad to avoid accidental taps and mimic typical game UI
- Add spacing style for bottom button row

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acb857f2f483248be43f997473aac1