### PR TITLE
Expand traps and player balance

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,7 +1,7 @@
-export const GRID_W=90,GRID_H=30,VIEW_W=30;export const PASSIVE_MANA=1,START_MANA=10,START_HP=10;
-export const CHEST_MANA=8;export const COSTS={arrow:9,rune:10,fire:16,spike:6};
-export const TRAP_RANGE=4,TRAP_DMG=2;export const RUNE_RADIUS=1,FIRE_DMG=3,FIRE_RADIUS=3,SAB_EXP_DMG=3,SAB_EXP_RADIUS=3,SPIKE_DMG=8;export const PLACE_RADIUS=4,PLACE_ZOOM=1.4;
-export const ARROW_AMMO=5;export const BURN_TURNS=2,BURN_DMG=1;export const RUNE_SLOW_TURNS=2;
+export const GRID_W=90,GRID_H=30,VIEW_W=30;export const PASSIVE_MANA=1,START_MANA=10,START_HP=15;
+export const CHEST_MANA=8;export const COSTS={arrow:9,rune:10,fire:16,spike:3};
+export const TRAP_RANGE=10,TRAP_DMG=2;export const RUNE_RADIUS=15,FIRE_DMG=3,FIRE_RADIUS=3,SAB_EXP_DMG=3,SAB_EXP_RADIUS=3,SPIKE_DMG=8;export const PLACE_RADIUS=4,PLACE_ZOOM=1.4;
+export const ARROW_AMMO=5,FIRE_AMMO=10,RUNE_TURNS=20;export const BURN_TURNS=2,BURN_DMG=1;export const RUNE_SLOW_TURNS=2;
 export const DASH_CD=8,DASH_COST=3;
 export const DENSITY_TILE_WEIGHT=.5,DENSITY_NEIGHBOR_WEIGHT=.25,PATIENCE_PROB=.2,PATROL_RADIUS=12;
 export const ENEMY={


### PR DESCRIPTION
## Summary
- Increase player starting health and arrow trap range
- Add ammo meters for fire totems and magic runes
- Limit spike floor placement and reduce its cost

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad055e05888324aafe6ac5a48640a8