### PR TITLE
Enable diagonal movement and attacks

### DIFF
--- a/game.js
+++ b/game.js
@@ -253,38 +253,34 @@ import './enemies.js';
     return a;
   }
 
-  function lineOfSightRowCol(a, b) {
-    if (a.x === b.x) {
-      const x = a.x;
-      const y1 = Math.min(a.y, b.y) + 1,
-        y2 = Math.max(a.y, b.y);
-      for (let y = y1; y < y2; y++) if (isWall(x, y)) return false;
-      return true;
-    } else if (a.y === b.y) {
-      const y = a.y;
-      const x1 = Math.min(a.x, b.x) + 1,
-        x2 = Math.max(a.x, b.x);
-      for (let x = x1; x < x2; x++) if (isWall(x, y)) return false;
-      return true;
+  function lineOfSight8(a, b) {
+    const dx = b.x - a.x,
+      dy = b.y - a.y,
+      adx = Math.abs(dx),
+      ady = Math.abs(dy);
+    if (!(a.x === b.x || a.y === b.y || adx === ady)) return false;
+    const sx = Math.sign(dx),
+      sy = Math.sign(dy);
+    let x = a.x + sx,
+      y = a.y + sy;
+    while (x !== b.x || y !== b.y) {
+      if (isWall(x, y)) return false;
+      x += sx;
+      y += sy;
     }
-    return false;
+    return true;
   }
   function clearShotToPlayer(from, ignore = null) {
-    if (!lineOfSightRowCol(from, state.player)) return false;
-    if (from.x === state.player.x) {
-      const x = from.x,
-        y1 = Math.min(from.y, state.player.y) + 1,
-        y2 = Math.max(from.y, state.player.y);
-      for (let y = y1; y < y2; y++)
-        if (state.enemies.some((e) => e !== ignore && e.x === x && e.y === y))
-          return false;
-    } else if (from.y === state.player.y) {
-      const y = from.y,
-        x1 = Math.min(from.x, state.player.x) + 1,
-        x2 = Math.max(from.x, state.player.x);
-      for (let x = x1; x < x2; x++)
-        if (state.enemies.some((e) => e !== ignore && e.x === x && e.y === y))
-          return false;
+    if (!lineOfSight8(from, state.player)) return false;
+    const dx = Math.sign(state.player.x - from.x),
+      dy = Math.sign(state.player.y - from.y);
+    let x = from.x + dx,
+      y = from.y + dy;
+    while (x !== state.player.x || y !== state.player.y) {
+      if (state.enemies.some((e) => e !== ignore && e.x === x && e.y === y))
+        return false;
+      x += dx;
+      y += dy;
     }
     return true;
   }
@@ -530,7 +526,7 @@ import './enemies.js';
     for (let y = cy - r; y <= cy + r; y++) {
       for (let x = cx - r; x <= cx + r; x++) {
         if (!inBounds(x, y)) continue;
-        if (Math.abs(cx - x) + Math.abs(cy - y) <= r)
+        if (Math.max(Math.abs(cx - x), Math.abs(cy - y)) <= r)
           drawOutlineRect(x, y, color, 0.18);
       }
     }
@@ -555,8 +551,10 @@ import './enemies.js';
   function updateDrops() {
     const next = [];
     for (const d of state.drops) {
-      const dist =
-        Math.abs(d.x - state.player.x) + Math.abs(d.y - state.player.y);
+      const dist = Math.max(
+        Math.abs(d.x - state.player.x),
+        Math.abs(d.y - state.player.y),
+      );
       if (dist <= 5 && dist > 0) {
         const dx = state.player.x > d.x ? 1 : state.player.x < d.x ? -1 : 0;
         const dy = state.player.y > d.y ? 1 : state.player.y < d.y ? -1 : 0;
@@ -977,9 +975,20 @@ import './enemies.js';
       const t = e.changedTouches[0];
       const dx = t.clientX - swipeStart.x,
         dy = t.clientY - swipeStart.y;
-      if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 24)
-        window.onMove(dx > 0 ? 'right' : 'left');
-      else if (Math.abs(dy) > 24) window.onMove(dy > 0 ? 'down' : 'up');
+      const ax = Math.abs(dx),
+        ay = Math.abs(dy);
+      if (ax > 24 && ay > 24)
+        window.onMove(
+          dy > 0
+            ? dx > 0
+              ? 'down-right'
+              : 'down-left'
+            : dx > 0
+              ? 'up-right'
+              : 'up-left',
+        );
+      else if (ax > ay && ax > 24) window.onMove(dx > 0 ? 'right' : 'left');
+      else if (ay > 24) window.onMove(dy > 0 ? 'down' : 'up');
       swipeStart = null;
     },
     { passive: true },
@@ -996,11 +1005,15 @@ import './enemies.js';
       [-1, 0],
       [0, 1],
       [0, -1],
+      [1, 1],
+      [1, -1],
+      [-1, 1],
+      [-1, -1],
     ];
     while (q.length) {
       const cur = q.shift();
       const d = dist[cur.y][cur.x] + 1;
-      for (let i = 0; i < 4; i++) {
+      for (let i = 0; i < dirs.length; i++) {
         const nx = cur.x + dirs[i][0],
           ny = cur.y + dirs[i][1];
         if (!inBounds(nx, ny)) continue;
@@ -1080,6 +1093,10 @@ import './enemies.js';
     else if (dir === 'down') playerMove(0, 1);
     else if (dir === 'left') playerMove(-1, 0);
     else if (dir === 'right') playerMove(1, 0);
+    else if (dir === 'up-left') playerMove(-1, -1);
+    else if (dir === 'up-right') playerMove(1, -1);
+    else if (dir === 'down-left') playerMove(-1, 1);
+    else if (dir === 'down-right') playerMove(1, 1);
   };
   function tryPlace(x, y) {
     const t = state.selectedTool,
@@ -1109,7 +1126,10 @@ import './enemies.js';
     if (isChest(x, y)) return { ok: false, reason: 'chest tile' };
     if (state.player.x === x && state.player.y === y)
       return { ok: false, reason: 'on player' };
-    const dist = Math.abs(state.player.x - x) + Math.abs(state.player.y - y);
+    const dist = Math.max(
+      Math.abs(state.player.x - x),
+      Math.abs(state.player.y - y),
+    );
     if (dist > PLACE_RADIUS)
       return {
         ok: false,
@@ -1158,12 +1178,8 @@ import './enemies.js';
           bestD = 1e9;
         for (const e of state.enemies) {
           if (e.kind === 'saboteur') continue;
-          const d = Math.abs(t.x - e.x) + Math.abs(t.y - e.y);
-          if (
-            d <= TRAP_RANGE &&
-            (t.x === e.x || t.y === e.y) &&
-            lineOfSightRowCol(t, e)
-          ) {
+          const d = Math.max(Math.abs(t.x - e.x), Math.abs(t.y - e.y));
+          if (d <= TRAP_RANGE && lineOfSight8(t, e)) {
             if (d < bestD) {
               best = e;
               bestD = d;
@@ -1268,6 +1284,10 @@ import './enemies.js';
       [-1, 0],
       [0, 1],
       [0, -1],
+      [1, 1],
+      [1, -1],
+      [-1, 1],
+      [-1, -1],
     ];
     const q = [start];
     const prev = {};
@@ -1307,6 +1327,10 @@ import './enemies.js';
       [-1, 0],
       [0, 1],
       [0, -1],
+      [1, 1],
+      [1, -1],
+      [-1, 1],
+      [-1, -1],
     ];
     const goals = [];
     for (const d of dirs) {
@@ -1325,7 +1349,10 @@ import './enemies.js';
         e.cooldown--;
         return false;
       }
-      const d = Math.abs(e.x - state.player.x) + Math.abs(e.y - state.player.y);
+      const d = Math.max(
+        Math.abs(e.x - state.player.x),
+        Math.abs(e.y - state.player.y),
+      );
       if (d <= ENEMY.archer.range && clearShotToPlayer(e, e)) {
         addProjectileFX(
           'projectile',
@@ -1344,7 +1371,10 @@ import './enemies.js';
       }
       return false;
     } else {
-      const d = Math.abs(e.x - state.player.x) + Math.abs(e.y - state.player.y);
+      const d = Math.max(
+        Math.abs(e.x - state.player.x),
+        Math.abs(e.y - state.player.y),
+      );
       const dmg = ENEMY[e.kind]?.touch || 0;
       if (d === 1 && dmg > 0) {
         state.hp -= dmg;
@@ -1364,6 +1394,10 @@ import './enemies.js';
       [-1, 0],
       [0, 1],
       [0, -1],
+      [1, 1],
+      [1, -1],
+      [-1, 1],
+      [-1, -1],
     ];
     let best = null;
     for (const d of dirs) {
@@ -1373,8 +1407,10 @@ import './enemies.js';
       const nk = nx + ',' + ny;
       if (occupied.has(nk)) continue;
       if (state.towers.some((t) => t.x === nx && t.y === ny)) continue;
-      const dist =
-        Math.abs(nx - state.player.x) + Math.abs(ny - state.player.y);
+      const dist = Math.max(
+        Math.abs(nx - state.player.x),
+        Math.abs(ny - state.player.y),
+      );
       const shot =
         dist <= ENEMY.archer.range && clearShotToPlayer({ x: nx, y: ny }, e);
       const score = Math.abs(dist - ENEMY.archer.range) + (shot ? 0 : 1);
@@ -1393,7 +1429,8 @@ import './enemies.js';
     let base = { x: state.player.x, y: state.player.y };
     if (
       state.lastMove &&
-      Math.abs(e.x - state.player.x) + Math.abs(e.y - state.player.y) > 4
+      Math.max(Math.abs(e.x - state.player.x), Math.abs(e.y - state.player.y)) >
+        4
     ) {
       const px = state.player.x + state.lastMove.dx,
         py = state.player.y + state.lastMove.dy;
@@ -1472,15 +1509,17 @@ import './enemies.js';
   function saboteurExplode(s) {
     for (const other of state.enemies) {
       if (other === s) continue;
-      const d = Math.abs(other.x - s.x) + Math.abs(other.y - s.y);
+      const d = Math.max(Math.abs(other.x - s.x), Math.abs(other.y - s.y));
       if (d <= SAB_EXP_RADIUS) {
         other.hp -= SAB_EXP_DMG;
         addFX('hit', other.x, other.y);
       }
     }
     if (
-      Math.abs(state.player.x - s.x) + Math.abs(state.player.y - s.y) <=
-      SAB_EXP_RADIUS
+      Math.max(
+        Math.abs(state.player.x - s.x),
+        Math.abs(state.player.y - s.y),
+      ) <= SAB_EXP_RADIUS
     ) {
       state.hp -= SAB_EXP_DMG;
       flashHP();
@@ -1581,7 +1620,10 @@ import './enemies.js';
   function pickSpawnPos() {
     const minR = SPAWN_MIN_RADIUS;
     const ring = state.map.spawners.filter((s) => {
-      const d = Math.abs(s.x - state.player.x) + Math.abs(s.y - state.player.y);
+      const d = Math.max(
+        Math.abs(s.x - state.player.x),
+        Math.abs(s.y - state.player.y),
+      );
       return d >= Math.max(8, minR) && d <= 18;
     });
     const behindRing = ring.filter((s) => s.x <= state.player.x - 2);
@@ -1591,7 +1633,10 @@ import './enemies.js';
         ? ring
         : state.map.spawners;
     const candidates = pool1.filter((p) => {
-      const d = Math.abs(p.x - state.player.x) + Math.abs(p.y - state.player.y);
+      const d = Math.max(
+        Math.abs(p.x - state.player.x),
+        Math.abs(p.y - state.player.y),
+      );
       return (
         d >= minR &&
         !(p.x === state.player.x && p.y === state.player.y) &&
@@ -1603,7 +1648,10 @@ import './enemies.js';
     let best = null,
       bestD = -1;
     for (const p of state.map.spawners) {
-      const d = Math.abs(p.x - state.player.x) + Math.abs(p.y - state.player.y);
+      const d = Math.max(
+        Math.abs(p.x - state.player.x),
+        Math.abs(p.y - state.player.y),
+      );
       if (d >= minR && d > bestD) {
         best = p;
         bestD = d;
@@ -1634,7 +1682,10 @@ import './enemies.js';
     const nearCount = state.enemies.reduce(
       (n, e) =>
         n +
-        (Math.abs(e.x - state.player.x) + Math.abs(e.y - state.player.y) <= 4
+        (Math.max(
+          Math.abs(e.x - state.player.x),
+          Math.abs(e.y - state.player.y),
+        ) <= 4
           ? 1
           : 0),
       0,

--- a/index.html
+++ b/index.html
@@ -58,15 +58,15 @@
 
     <!-- D-pad controls -->
     <div class="dpad-row" id="dpad">
-      <div></div>
+      <button data-dir="up-left">↖</button>
       <button data-dir="up">▲</button>
-      <div></div>
+      <button data-dir="up-right">↗</button>
       <button data-dir="left">◀</button>
       <div></div>
       <button data-dir="right">▶</button>
-      <div></div>
+      <button data-dir="down-left">↙</button>
       <button data-dir="down">▼</button>
-      <div></div>
+      <button data-dir="down-right">↘</button>
     </div>
 
     <!-- Trap carousel -->


### PR DESCRIPTION
## Summary
- Allow player and enemies to move diagonally via pathfinding and input updates
- Let arrow traps and enemy archers fire along diagonal lines using new line-of-sight checks
- Extend touch and on-screen arrow controls with diagonal directions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae2ba400548324af18ead02929d461