### PR TITLE
Fix diagonal movement and targeting

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,15 +58,15 @@
 
     <!-- D-pad controls -->
     <div class="dpad-row" id="dpad">
-      <div></div>
+      <button data-dir="up-left">↖</button>
       <button data-dir="up">▲</button>
-      <div></div>
+      <button data-dir="up-right">↗</button>
       <button data-dir="left">◀</button>
       <div></div>
       <button data-dir="right">▶</button>
-      <div></div>
+      <button data-dir="down-left">↙</button>
       <button data-dir="down">▼</button>
-      <div></div>
+      <button data-dir="down-right">↘</button>
     </div>
 
     <!-- Trap carousel -->


### PR DESCRIPTION
## Summary
- Correct diagonal movement for player inputs using a shared direction map
- Allow traps and archers to fire along diagonal lines with improved line-of-sight checks
- Prevent enemies from cutting corners when moving diagonally

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae2ba400548324af18ead02929d461