### PR TITLE
Use entity z for mesh positions

### DIFF
--- a/game.js
+++ b/game.js
@@ -713,8 +713,8 @@ import * as THREE from 'three';
     }
     playerMesh.position.set(
       state.player.x + 0.5,
-      state.player.y + 0.5 + bob,
-      0.2,
+      state.player.y + 0.5,
+      state.player.z + bob + 0.2,
     );
   }
   function drawEnemy(e) {
@@ -752,7 +752,7 @@ import * as THREE from 'three';
       enemyMeshes.set(e, mesh);
       scene.add(mesh);
     }
-    mesh.position.set(e.x + 0.5, e.y + 0.5 + bob, 0.2);
+    mesh.position.set(e.x + 0.5, e.y + 0.5, e.z + bob + 0.2);
   }
   function draw() {
     const rect = canvas.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- Render player and enemies using their z coordinates so vertical animations apply relative to height.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af5e60ff28832493892d190110004a