### PR TITLE
Fix three.js import path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/game.js
+++ b/game.js
@@ -44,7 +44,7 @@ import {
 import './ui.js';
 import { buildMap } from './map.js';
 import './enemies.js';
-import * as THREE from 'three';
+import * as THREE from './node_modules/three/build/three.module.js';
 
 (() => {
   let tileSize = 1,


### PR DESCRIPTION
## Summary
- resolve module path by importing three.js from local build
- ignore node_modules

## Testing
- `npm test`
- attempted to load `index.html` in Puppeteer (failed: libatk-1.0.so.0 missing)


------
https://chatgpt.com/codex/tasks/task_e_68af61ce2c008324bc434821a4004e1a