### PR TITLE
Rotate floor meshes for correct terrain rendering

### DIFF
--- a/game.js
+++ b/game.js
@@ -398,6 +398,7 @@ import * as THREE from './lib/three.module.js';
           mesh.position.set(x + 0.5, y + 0.5, (z + 1) / 2);
         } else {
           mesh = new THREE.Mesh(floorGeo, floorMat);
+          mesh.rotation.x = -Math.PI / 2;
           mesh.position.set(x + 0.5, y + 0.5, z);
         }
         terrainGroup.add(mesh);


### PR DESCRIPTION
## Summary
- Rotate floor meshes so they lie flat on the terrain

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af68eedce483248872f7a0f4e7e92e