### PR TITLE
Adjust camera orientation and terrain geometry

### DIFF
--- a/game.js
+++ b/game.js
@@ -74,8 +74,9 @@ import * as THREE from './lib/three.module.js';
     0.1,
     1000,
   );
-  camera.up.set(0, 0, 1);
+  camera.up.set(0, 1, 0);
   camera.position.set(0, 0, 10);
+  camera.lookAt(0, 0, 0);
   scene.add(new THREE.AmbientLight(0xffffff, 0.8));
   const dirLight = new THREE.DirectionalLight(0xffffff, 0.5);
   dirLight.position.set(0, 0, 10);
@@ -350,10 +351,12 @@ import * as THREE from './lib/three.module.js';
 
     // shared geometry and materials for floors and walls
     const floorGeo = new THREE.PlaneGeometry(1, 1);
+    floorGeo.rotateX(-Math.PI / 2);
     const floorMat = new THREE.MeshBasicMaterial({
       color: new THREE.Color(COLORS.floor),
     });
     const wallGeo = new THREE.BoxGeometry(1, 1, 1);
+    wallGeo.rotateX(-Math.PI / 2);
     const wallMat = new THREE.MeshBasicMaterial({
       color: new THREE.Color(COLORS.wall),
     });


### PR DESCRIPTION
## Summary
- Align camera with Y-up convention and look at the origin for consistent orientation
- Rotate floor and wall geometries to prevent vertical rendering artifacts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af8325ac04832498f09817a4360a42