### PR TITLE
Render control nodes in terrain

### DIFF
--- a/game.js
+++ b/game.js
@@ -376,6 +376,26 @@ import * as THREE from './lib/three.module.js';
         terrainGroup.add(mesh);
       }
     }
+
+    // draw control nodes
+    for (const node of state.map.nodes) {
+      const color = node.captured
+        ? COLORS.nodeCaptured
+        : node.capturing
+        ? COLORS.nodeCapturing
+        : COLORS.nodeIdle;
+      const geo = new THREE.CircleGeometry(node.size / 2, 16);
+      const mat = new THREE.MeshBasicMaterial({
+        color: new THREE.Color(color),
+      });
+      const mesh = new THREE.Mesh(geo, mat);
+      mesh.position.set(
+        node.x + node.size / 2,
+        node.y + node.size / 2,
+        node.z + 0.01,
+      );
+      terrainGroup.add(mesh);
+    }
     terrainValid = true;
   }
   function drawOutlineRectTo(tctx, x, y, color, alpha = 0.28) {


### PR DESCRIPTION
## Summary
- Render control nodes on the map with colors for idle, capturing, and captured states
- Keep terrain invalidation so node visuals refresh when capture states change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af95ebe05883249ac87d3c5fe56c90