### PR TITLE
Fix vertical movement keys

### DIFF
--- a/game.js
+++ b/game.js
@@ -816,8 +816,8 @@ import * as THREE from './lib/three.module.js';
   document.addEventListener('keydown', (e) => {
     if (state.won || state.lost || state.placeMode) return;
     const key = e.key.toLowerCase();
-    if (['arrowup', 'w'].includes(key)) playerMove(0, 1, e.shiftKey);
-    else if (['arrowdown', 's'].includes(key)) playerMove(0, -1, e.shiftKey);
+    if (['arrowup', 'w'].includes(key)) playerMove(0, -1, e.shiftKey);
+    else if (['arrowdown', 's'].includes(key)) playerMove(0, 1, e.shiftKey);
     else if (['arrowleft', 'a'].includes(key)) playerMove(-1, 0, e.shiftKey);
     else if (['arrowright', 'd'].includes(key)) playerMove(1, 0, e.shiftKey);
     else if (key === 'q') toggleDashArm();


### PR DESCRIPTION
## Summary
- Correct vertical movement so ArrowUp/W moves the player upward and ArrowDown/S moves downward

## Testing
- `npm test`
- `node <<'NODE'
let state={player:{x:0,y:5,z:0}};
function playerMove(dx,dy){state.player.x += dx; state.player.y += dy;}
console.log('start', state.player.y);
playerMove(0,-1); // ArrowUp
console.log('after Up', state.player.y);
playerMove(0,1); // ArrowDown
console.log('after Down', state.player.y);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68af98ff25f48324b95dcf75ac81eca2