### PR TITLE
Optimize pathExists with index-based queue

### DIFF
--- a/map.js
+++ b/map.js
@@ -171,6 +171,7 @@ function dist1(a, b) {
 }
 export function pathExists(grid, start, goal) {
   const q = [start];
+  let qi = 0;
   const seen = new Set([start.x + ',' + start.y + ',' + start.z]);
   const dirs = [
     [1, 0, 0],
@@ -180,8 +181,8 @@ export function pathExists(grid, start, goal) {
     [0, 0, 1],
     [0, 0, -1],
   ];
-  while (q.length) {
-    const cur = q.shift();
+  while (qi < q.length) {
+    const cur = q[qi++];
     if (cur.x === goal.x && cur.y === goal.y && cur.z === goal.z) return true;
     for (let i = 0; i < dirs.length; i++) {
       const nx = cur.x + dirs[i][0],


### PR DESCRIPTION
## Summary
- refactor BFS queue in `pathExists` to avoid costly `shift()`
- keep 3D neighbor logic intact

## Testing
- `npm test`
- `node -e "import { buildMap } from './map.js'; import { performance } from 'node:perf_hooks'; const runs=100; const t0=performance.now(); for(let i=0;i<runs;i++) buildMap(); const t1=performance.now(); console.log('avg ms', (t1-t0)/runs);"`


------
https://chatgpt.com/codex/tasks/task_e_68afa9a71d308324a5a7d6598c50384b