### PR TITLE
Fix state initialization to maintain current state for UI closures

### DIFF
--- a/game.js
+++ b/game.js
@@ -50,7 +50,7 @@ import * as THREE from './lib/three.module.js';
     tilePad = 0,
     animT = 0;
   let terrainValid = false;
-  let state;
+  const state = {};
 
   const canvas = document.getElementById('game');
   const renderer = new THREE.WebGLRenderer({ canvas });
@@ -1590,7 +1590,8 @@ import * as THREE from './lib/three.module.js';
   }
   function resetState() {
     const map = buildMap();
-    state = {
+    Object.keys(state).forEach((k) => delete state[k]);
+    Object.assign(state, {
       map,
       turn: 0,
       hp: START_HP,
@@ -1625,7 +1626,7 @@ import * as THREE from './lib/three.module.js';
       spikePlaced: false,
       enemyCap: ENEMY_CAP,
       exitWarned: false,
-    };
+    });
     state.visited[state.player.y][state.player.x] = true;
     clearLog();
     logMsg('v2.9.7: trap icons, ammo meters, and fire totem AoE indicator.');


### PR DESCRIPTION
## Summary
- Initialize `state` as an empty object before calling `initUI`
- Mutate the existing `state` object in `resetState()` using `Object.assign`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afb2b0d6e88324a4395e345b02db13