### PR TITLE
Fix node mesh z-fighting via polygon offset

### DIFF
--- a/game.js
+++ b/game.js
@@ -257,6 +257,9 @@ import * as THREE from './lib/three.module.js';
       const mat = new THREE.MeshBasicMaterial({
         color: new THREE.Color(color),
       });
+      mat.polygonOffset = true;
+      mat.polygonOffsetFactor = -1;
+      mat.polygonOffsetUnits = -1;
       const mesh = new THREE.Mesh(geo, mat);
       mesh.position.set(
         node.x + node.size / 2,


### PR DESCRIPTION
## Summary
- enable polygon offset for control node meshes to render above floor

## Testing
- `npm test`
- `node -e "const {chromium}=require('playwright');(async()=>{const browser=await chromium.launch();const page=await browser.newPage();await page.goto('file://' + process.cwd() + '/index.html');await page.waitForTimeout(1000);await page.screenshot({path:'screenshot.png'});await browser.close();})();"` *(fails: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_68b054ea63948324a323cf5b34c1924c