### PR TITLE
Fix floor orientation for top-down camera

### DIFF
--- a/game.js
+++ b/game.js
@@ -246,7 +246,6 @@ import * as THREE from './lib/three.module.js';
 
     // shared geometry and materials for floors and walls
     const floorGeo = new THREE.PlaneGeometry(1, 1);
-    floorGeo.rotateX(-Math.PI / 2);
     const floorMat = new THREE.MeshBasicMaterial({
       color: new THREE.Color(COLORS.floor),
     });
@@ -280,7 +279,6 @@ import * as THREE from './lib/three.module.js';
           ? COLORS.nodeCapturing
           : COLORS.nodeIdle;
       const geo = new THREE.CircleGeometry(node.size / 2, 16);
-      geo.rotateX(-Math.PI / 2);
       const mat = new THREE.MeshBasicMaterial({
         color: new THREE.Color(color),
       });


### PR DESCRIPTION
## Summary
- Fix floor plane orientation so it's visible to the top-down camera
- Align control node markers with the corrected floor orientation

## Testing
- `npm test`
- `npx prettier game.js -w`


------
https://chatgpt.com/codex/tasks/task_e_68b0aa78460c8324959e468d851d3db6