### PR TITLE
Fix floor tile z-level to base plane

### DIFF
--- a/game.js
+++ b/game.js
@@ -253,6 +253,7 @@ import * as THREE from './lib/three.module.js';
     const floorMat = new THREE.MeshBasicMaterial({
       color: new THREE.Color(COLORS.floor),
     });
+    const floorZ = 0.01;
     const wallGeo = new THREE.BoxGeometry(1, 1, 1);
     wallGeo.rotateX(-Math.PI / 2);
     const wallMat = new THREE.MeshBasicMaterial({
@@ -270,7 +271,7 @@ import * as THREE from './lib/three.module.js';
           mesh.position.set(x + 0.5, y + 0.5, (z + 1) / 2);
         } else {
           mesh = new THREE.Mesh(floorGeo, floorMat);
-          mesh.position.set(x + 0.5, y + 0.5, z);
+          mesh.position.set(x + 0.5, y + 0.5, floorZ);
         }
         terrainGroup.add(mesh);
       }


### PR DESCRIPTION
## Summary
- Place floor tiles at a constant z-height to keep them aligned with wall bases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ddf778b0832497aa5403aa5e4071